### PR TITLE
Added a backup service name to latlontoutm

### DIFF
--- a/smarc_bt/launch/smarc_bt.launch
+++ b/smarc_bt/launch/smarc_bt.launch
@@ -17,6 +17,7 @@
 	<arg name="follow_action_namespace" default="ctrl/leader_follower_action" />
 	<arg name="start_stop_dvl_namespace" default="core/toggle_dvl" />
 	<arg name="latlontoutm_service" default="/$(arg robot_name)/dr/lat_lon_to_utm" />
+	<arg name="latlontoutm_service_alternative" default="/$(arg robot_name)/lat_lon_to_utm" />
 	<arg name="base_link" default="$(arg robot_name)/base_link" />
 	<arg name="utm_link" default="utm" />
 	<arg name="local_link" default="map" />
@@ -55,6 +56,7 @@
 		<param name="follow_action_namespace" value="$(arg follow_action_namespace)" />
 		<param name="start_stop_dvl_namespace" value="$(arg start_stop_dvl_namespace)" />
 		<param name="latlontoutm_service" value="$(arg latlontoutm_service)" />
+		<param name="latlontoutm_service_alternative" value="$(arg latlontoutm_service_alternative)" />
 		<param name="base_link" value="$(arg base_link)" />
 		<param name="utm_link" value="$(arg utm_link)" />
 		<param name="local_link" value="$(arg local_link)" />

--- a/smarc_bt/src/auv_config.py
+++ b/smarc_bt/src/auv_config.py
@@ -36,6 +36,8 @@ class AUVConfig(object):
         self.START_STOP_DVL_NAMESPACE = 'core/toggle_dvl'
 
         self.LATLONTOUTM_SERVICE = '/'+self.robot_name+'/dr/lat_lon_to_utm'
+        # in cases where the above service couldnt be found for some reason
+        self.LATLONTOUTM_SERVICE_ALTERNATIVE = '/'+self.robot_name+'/lat_lon_to_utm'
 
         # tf frame names
         self.BASE_LINK = self.robot_name+'/base_link'

--- a/smarc_bt/src/bt_actions.py
+++ b/smarc_bt/src/bt_actions.py
@@ -668,13 +668,19 @@ class A_UpdateNeptusVehicleState(pt.behaviour.Behaviour):
 
 
 class A_UpdateNeptusPlanDB(pt.behaviour.Behaviour):
-    def __init__(self, plandb_topic, utm_link, local_link, latlontoutm_service_name):
+    def __init__(self,
+                 plandb_topic,
+                 utm_link,
+                 local_link,
+                 latlontoutm_service_name,
+                 latlontoutm_service_name_alternative):
         super(A_UpdateNeptusPlanDB, self).__init__("A_UpdateNeptusPlanDB")
         self.bb = pt.blackboard.Blackboard()
         # neptus sends lat/lon, which we convert to utm, which we then convert to local
         self.utm_link = utm_link
         self.local_link = local_link
         self.latlontoutm_service_name = latlontoutm_service_name
+        self.latlontoutm_service_name_alternative = latlontoutm_service_name_alternative
 
         # the message body is largely the same, so we can re-use most of it
         self.plandb_msg = PlanDB()
@@ -756,8 +762,13 @@ class A_UpdateNeptusPlanDB(pt.behaviour.Behaviour):
         # there is a plan we can at least look at
         mission_plan = MissionPlan(plan_frame = self.utm_link,
                                    plandb_msg = plandb_msg,
-                                   latlontoutm_service_name = self.latlontoutm_service_name)
+                                   latlontoutm_service_name = self.latlontoutm_service_name,
+                                   latlontoutm_service_name_alternative = self.latlontoutm_service_name_alternative)
 
+        if mission_plan.no_service:
+            self.feedback_message = "MISSION PLAN HAS NO SERVICE"
+            rospy.logerr(self.feedback_message)
+            return
 
         self.bb.set(bb_enums.MISSION_PLAN_OBJ, mission_plan)
         self.bb.set(bb_enums.ENABLE_AUTONOMY, False)

--- a/smarc_bt/src/mission_plan.py
+++ b/smarc_bt/src/mission_plan.py
@@ -55,6 +55,7 @@ class MissionPlan:
     def __init__(self,
                  plandb_msg,
                  latlontoutm_service_name,
+                 latlontoutm_service_name_alternative,
                  plan_frame = 'utm',
                  waypoints=None
                  ):
@@ -65,7 +66,25 @@ class MissionPlan:
         self.plan_id = plandb_msg.plan_id
         self.plan_frame = plan_frame
 
+        # test if the service is usable!
+        # if not, test the backup
+        # if that fails too, raise exception
+        self.no_service = False
         self.latlontoutm_service_name = latlontoutm_service_name
+        try:
+            rospy.loginfo("Waiting (10s) lat_lon_to_utm service:{}".format(self.latlontoutm_service_name))
+            rospy.wait_for_service(self.latlontoutm_service_name, timeout=10)
+        except:
+            rospy.logwarn(str(self.latlontoutm_service_name)+" service could be connected to!")
+            self.latlontoutm_service_name = latlontoutm_service_name_alternative
+            rospy.logwarn("Setting the service to the alternative:{}".format(self.latlontoutm_service_name))
+            try:
+                rospy.loginfo("Waiting (10s) lat_lon_to_utm service alternative:{}".format(self.latlontoutm_service_name))
+                rospy.wait_for_service(self.latlontoutm_service_name, timeout=10)
+            except:
+                rospy.logerr("No lat_lon_to_utm service could be reached! The BT can not accept missions in this state!")
+                rospy.logerr("The BT received a mission, tried to convert it to UTM coordinates using {} service and then {} as the backup and neither of them could be reached! Check the navigation/DR stack, the TF tree and the services!".format(latlontoutm_service_name, latlontoutm_service_name_alternative))
+                self.no_service = True
 
         self.aborted = False
 
@@ -75,7 +94,7 @@ class MissionPlan:
 
         # if waypoints are given directly, then skip reading the plandb message
         if waypoints is None:
-            self.waypoints = MissionPlan.read_plandb(plandb_msg, self.latlontoutm_service_name)
+            self.waypoints = self.read_plandb(plandb_msg)
         else:
             self.waypoints = waypoints
 
@@ -89,18 +108,20 @@ class MissionPlan:
         self.creation_time = time.time()
 
 
-    @staticmethod
-    def latlon_to_utm(lat, lon, z, latlontoutm_service_name):
-        rospy.loginfo("Waiting at most 10s for latlontoutm service "+str(latlontoutm_service_name))
+    def latlon_to_utm(self,
+                      lat,
+                      lon,
+                      z):
+        rospy.loginfo("Waiting at most 1s for latlontoutm service "+str(self.latlontoutm_service_name))
         try:
-            rospy.wait_for_service(latlontoutm_service_name, timeout=10)
+            rospy.wait_for_service(self.latlontoutm_service_name, timeout=1)
         except:
-            rospy.logwarn(str(latlontoutm_service_name)+" service could be connected to! No mission received!")
+            rospy.logwarn(str(self.latlontoutm_service_name)+" service could be connected to! No mission received!")
             return (None, None)
 
         rospy.loginfo("Got latlontoutm service")
         try:
-            latlontoutm_service = rospy.ServiceProxy(latlontoutm_service_name,
+            latlontoutm_service = rospy.ServiceProxy(self.latlontoutm_service_name,
                                                      LatLonToUTM)
             gp = GeoPoint()
             gp.latitude = np.degrees(lat)
@@ -109,13 +130,12 @@ class MissionPlan:
             res = latlontoutm_service(gp)
             return (res.utm_point.x, res.utm_point.y)
         except rospy.service.ServiceException:
-            rospy.logerr_throttle_identical(5, "LatLon to UTM service failed! namespace:{}".format(latlontoutm_service_name))
+            rospy.logerr_throttle_identical(5, "LatLon to UTM service failed! namespace:{}".format(self.latlontoutm_service_name))
             return (None, None)
 
 
 
-    @staticmethod
-    def read_plandb(plandb, latlontoutm_service_name):
+    def read_plandb(self, plandb):
         """
         planddb message is a bunch of nested objects,
         we want a list of waypoints in the local frame,
@@ -136,7 +156,13 @@ class MissionPlan:
             # probably every maneuver has lat lon z in them, but just in case...
             # goto and sample are identical, with sample having extra "syringe" booleans...
             if man_imc_id == imc_enums.MANEUVER_GOTO or man_imc_id == imc_enums.MANEUVER_SAMPLE:
-                utm_x, utm_y = MissionPlan.latlon_to_utm(maneuver.lat, maneuver.lon, -maneuver.z, latlontoutm_service_name)
+                if self.no_service:
+                    rospy.logwarn("The BT can not reach the latlon_to_utm service! Can not do waypoints!")
+                    continue
+
+                utm_x, utm_y = self.latlon_to_utm(maneuver.lat,
+                                                  maneuver.lon,
+                                                  -maneuver.z)
                 if utm_x is None:
                     rospy.loginfo("Could not convert LATLON to UTM! Skipping point:{}".format((maneuver.lat, maneuver.lon, man_name)))
                     continue
@@ -168,7 +194,7 @@ class MissionPlan:
                 rospy.logwarn("SKIPPING UNIMPLEMENTED MANEUVER: id:{}, name:{}".format(man_imc_id, man_name))
 
         if len(waypoints) <= 0:
-            rospy.logwarn("NO MANEUVERS IN MISSION PLAN!")
+            rospy.logerr("NO MANEUVERS IN MISSION PLAN!")
 
         return waypoints
 

--- a/smarc_bt/src/smarc_bt.py
+++ b/smarc_bt/src/smarc_bt.py
@@ -140,7 +140,8 @@ def const_tree(auv_config):
                 A_UpdateNeptusPlanDB(auv_config.PLANDB_TOPIC,
                                      auv_config.UTM_LINK,
                                      auv_config.LOCAL_LINK,
-                                     auv_config.LATLONTOUTM_SERVICE),
+                                     auv_config.LATLONTOUTM_SERVICE,
+                                     auv_config.LATLONTOUTM_SERVICE_ALTERNATIVE),
                 A_UpdateNeptusPlanControl(auv_config.PLAN_CONTROL_TOPIC),
                 A_VizPublishPlan(auv_config.PLAN_VIZ_TOPIC)
                                      ])


### PR DESCRIPTION
On lolo currently the lat_lon_to_utm service is not under `/lolo/dr/lat_lon_to_utm`, this change lets the BT try the `/lolo/dr/lat_lon_to_utm` first and if that is not there, it falls back to `/lolo/lat_lon_to_utm`.

Tested in simulated sam, and lolo.