### PR TITLE
disabled automatic bagging of bt

### DIFF
--- a/smarc_bt/src/smarc_bt.py
+++ b/smarc_bt/src/smarc_bt.py
@@ -422,7 +422,7 @@ def const_tree(auv_config):
                               run_tree
                     ])
 
-    return ptr.trees.BehaviourTree(root)
+    return ptr.trees.BehaviourTree(root,record_rosbag=False)
 
 
 def main():


### PR DESCRIPTION
Unsure of how necessary this is, but it seems that the behavior tree [automatically creates ros bags](http://docs.ros.org/en/kinetic/api/py_trees_ros/html/tutorials.html#tutorial-9-bags)

![image](https://user-images.githubusercontent.com/53016036/177208505-9fe6c7e3-2faa-472a-b842-7498184522dc.png)

This proved to be an issue for me as the bags unsuspectedly filled my VM hard disk, making it impossible to connect 

![image](https://user-images.githubusercontent.com/53016036/177208671-0146937f-117d-4eaf-bcfc-794b0b2d1b34.png)

